### PR TITLE
Include case to check for both value and reference equality

### DIFF
--- a/library/src/main/java/com/github/kakavip/util/ObjectUtil.java
+++ b/library/src/main/java/com/github/kakavip/util/ObjectUtil.java
@@ -15,7 +15,7 @@ public class ObjectUtil {
      * @return true if the arguments are equal to each other and false otherwise.
      */
     public static boolean equals(Object a, Object b) {
-        return a == b;
+        return (a == b) || (a != null && a.equals(b));
     }
 
     /**

--- a/library/src/test/java/com/github/kakavip/util/ObjectUtilTest.java
+++ b/library/src/test/java/com/github/kakavip/util/ObjectUtilTest.java
@@ -1,0 +1,20 @@
+package com.github.kakavip.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class ObjectUtilTest {
+
+    @Test
+    public void test_equals_differentReference() throws Exception {
+        assertTrue(ObjectUtil.equals(new String("Test"), new String("Test")));
+    }
+
+    @Test
+    public void test_equals_sameReference() throws Exception {
+        String a = "Test";
+        String b = "Test";
+        assertTrue(ObjectUtil.equals(a, b));
+    }
+}


### PR DESCRIPTION
Hiện tại thì hàm equals đang chỉ check là có cùng reference (==), nên nếu dùng

`ObjectUtil.equals(new String("Test"), new String("Test"))`

sẽ trả về false mặc dù 2 String đều có cùng nội dung.

Đoạn code mới đc lấy từ source code của java 7 và có thể check sự giống nhau về cả reference lẫn content. Tuy nhiên với object thì người dùng phải tự override hàm equals.